### PR TITLE
chore: suppress lint for import issues

### DIFF
--- a/batched/batch_processor.py
+++ b/batched/batch_processor.py
@@ -194,7 +194,7 @@ class BatchProcessor(Generic[T, U]):
         Returns:
             U: The inferred result.
         """
-        import asyncio
+        import asyncio  # noqa: PLC0415
 
         if isinstance(item, list):
             futures = self._schedule(item)

--- a/batched/inference/helper.py
+++ b/batched/inference/helper.py
@@ -57,8 +57,8 @@ def torch_or_np(item: Any):
 
 
 def stack_features(
-    inputs: list[dict[str, Feature]], 
-    pad_tokens: dict[str, int], 
+    inputs: list[dict[str, Feature]],
+    pad_tokens: dict[str, int],
     padding_side: str = "right"
 ) -> dict[str, Feature]:
     """

--- a/batched/inference/model_batch_processor.py
+++ b/batched/inference/model_batch_processor.py
@@ -131,7 +131,7 @@ class ModelBatchProcessor(BatchProcessor[dict[str, Feature], Feature]):
         Returns:
             ModelOutputs: The processed model outputs.
         """
-        import asyncio
+        import asyncio  # noqa: PLC0415
 
         features = args[0] if args else kwargs
         unstacked_features = unstack_features(features)

--- a/batched/utils.py
+++ b/batched/utils.py
@@ -186,7 +186,7 @@ class AsyncDiskCache(AsyncCache[T, U]):
         **kwargs: Any,
     ) -> None:
         with ensure_import("diskcache"):
-            import diskcache
+            import diskcache  # noqa: PLC0415
 
         path = Path(cache_dir).expanduser().resolve()
         path.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Problem

Several files have imports inside methods that violate the `PLC0415` linting rule:
- `batched/batch_processor.py:197` - `import asyncio` inside `acall()` method
- `batched/inference/model_batch_processor.py:134` - `import asyncio` inside `acall()` method  
- `batched/utils.py:189` - `import diskcache` inside `AsyncDiskCache.__init__()` method

## Solution

Add `# noqa: PLC0415` comments to suppress these specific violations. The imports remain in their current locations to preserve:
- Performance benefits of conditional importing
- Optional dependency handling for `diskcache`
- Async-only import requirements

## Changes Made

- Add `# noqa: PLC0415` to asyncio imports in `acall()` methods
- Add `# noqa: PLC0415` to diskcache import in `AsyncDiskCache.__init__()`

## Testing

- [x] `make lint` passes without errors
- [x] All existing tests continue to pass 